### PR TITLE
vSLAM and frame LSH

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -14,11 +14,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: rustfmt
 
@@ -38,11 +38,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
           components: clippy
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nightly toolchain
+      - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/akaze/Cargo.toml
+++ b/akaze/Cargo.toml
@@ -20,7 +20,7 @@ derive_more = { version = "0.99.16", default-features = false }
 nshare = { version = "0.7.0", features = ["ndarray", "image"] }
 ndarray = { version = "0.15.3", default-features = false }
 float-ord = { version = "0.3.1", default-features = false }
-space = "0.14.0"
+space = "0.14.2"
 bitarray = "0.5.1"
 
 

--- a/cv-reconstruction/Cargo.toml
+++ b/cv-reconstruction/Cargo.toml
@@ -16,9 +16,9 @@ eight-point = { version = "0.8.0", path = "../eight-point" }
 lambda-twist = { version = "0.7.0", path = "../lambda-twist" }
 cv-optimize = { version = "0.1.0", path = "../cv-optimize" }
 akaze = { version = "0.7.0", path = "../akaze" }
-space = { version = "0.14.0", default-features = false }
+space = { version = "0.14.2", default-features = false }
 maplit = { version = "1.0.2", default-features = false }
-log = { version = "0.4.14", default-features = false}
+log = { version = "0.4.14", default-features = false }
 itertools = { version = "0.10.1", default-features = false }
 image = { version = "0.23.14", default-features = false }
 ply-rs = { version = "0.1.3", default-features = false }
@@ -27,7 +27,7 @@ conv = { version = "0.3.3", default-features = false }
 bitarray = { version = "0.5.1", default-features = false, features = ["space"] }
 rstar = { version = "0.9.0", default-features = false }
 serde = { version = "1.0.126", features = ["derive"], optional = true }
-slotmap = { version = "1.0.5" }
+slotmap = "1.0.5"
 hgg = { version = "0.3.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
 hamming-lsh = "0.2.0"

--- a/cv-reconstruction/Cargo.toml
+++ b/cv-reconstruction/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Geordon Worley <vadixidav@gmail.com>"]
 edition = "2018"
 
 [features]
-serde-serialize = ["serde", "cv-core/serde-serialize", "bitarray/serde", "cv-pinhole/serde-serialize", "bitarray/serde", "slotmap/serde", "hgg/serde"]
+serde-serialize = ["serde", "cv-core/serde-serialize", "bitarray/serde", "cv-pinhole/serde-serialize", "bitarray/serde", "slotmap/serde", "hgg/serde", "hamming-lsh/serde"]
 
 [dependencies]
 argmin = "0.4.5"
@@ -30,3 +30,4 @@ serde = { version = "1.0.126", features = ["derive"], optional = true }
 slotmap = { version = "1.0.5" }
 hgg = { version = "0.3.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
+hamming-lsh = "0.2.0"

--- a/cv-reconstruction/src/lib.rs
+++ b/cv-reconstruction/src/lib.rs
@@ -923,23 +923,26 @@ where
             .filter(|&(_, distance)| distance < self.settings.match_threshold)
             .map(|(FeatureMatch(a, b), _)| FeatureMatch(view_a.landmarks[a], view_b.landmarks[b]));
 
-        // Geometrically verify if the landmark pairs would be able to totally combine within tollerances.
+        // Check to make sure the landmarks aren't the same landmark and geometrically
+        // verify if the landmark pairs would be able to totally combine within tollerances.
         let matches: Vec<FeatureMatch<LandmarkKey>> = matches
             .filter(|&FeatureMatch(landmark_a, landmark_b)| {
-                self.triangulate_landmark_with_appended_observations_and_verify(
-                    reconstruction_key,
-                    landmark_a,
-                    reconstruction.landmarks[landmark_b]
-                        .observations
-                        .iter()
-                        .map(|(&view, &feature)| {
-                            (
-                                reconstruction.views[view].pose,
-                                self.data.frames[view_b.frame].features[feature].keypoint,
-                            )
-                        }),
-                )
-                .is_some()
+                landmark_a != landmark_b
+                    && self
+                        .triangulate_landmark_with_appended_observations_and_verify(
+                            reconstruction_key,
+                            landmark_a,
+                            reconstruction.landmarks[landmark_b]
+                                .observations
+                                .iter()
+                                .map(|(&view, &feature)| {
+                                    (
+                                        reconstruction.views[view].pose,
+                                        self.data.frames[view_b.frame].features[feature].keypoint,
+                                    )
+                                }),
+                        )
+                        .is_some()
             })
             .collect();
 

--- a/cv-reconstruction/src/lib.rs
+++ b/cv-reconstruction/src/lib.rs
@@ -938,7 +938,9 @@ where
                                 .map(|(&view, &feature)| {
                                     (
                                         reconstruction.views[view].pose,
-                                        self.data.frames[view_b.frame].features[feature].keypoint,
+                                        self.data.frames[reconstruction.views[view].frame].features
+                                            [feature]
+                                            .keypoint,
                                     )
                                 }),
                         )

--- a/cv-reconstruction/src/settings.rs
+++ b/cv-reconstruction/src/settings.rs
@@ -134,6 +134,12 @@ pub struct VSlamSettings {
         serde(default = "default_reconstruction_optimization_iterations")
     )]
     pub reconstruction_optimization_iterations: usize,
+    /// The number of most similar frames to attempt to match when tracking.
+    #[cfg_attr(
+        feature = "serde-serialize",
+        serde(default = "default_tracking_frames")
+    )]
+    pub tracking_frames: usize,
 }
 
 impl Default for VSlamSettings {
@@ -162,6 +168,7 @@ impl Default for VSlamSettings {
             many_view_landmarks: default_many_view_landmarks(),
             reconstruction_optimization_iterations: default_reconstruction_optimization_iterations(
             ),
+            tracking_frames: default_tracking_frames(),
         }
     }
 }
@@ -252,4 +259,8 @@ fn default_many_view_landmarks() -> usize {
 
 fn default_reconstruction_optimization_iterations() -> usize {
     1
+}
+
+fn default_tracking_frames() -> usize {
+    8
 }

--- a/cv-reconstruction/src/settings.rs
+++ b/cv-reconstruction/src/settings.rs
@@ -262,5 +262,5 @@ fn default_reconstruction_optimization_iterations() -> usize {
 }
 
 fn default_tracking_frames() -> usize {
-    8
+    16
 }

--- a/cv/Cargo.toml
+++ b/cv/Cargo.toml
@@ -50,7 +50,7 @@ eight-point = { optional = true, version = "0.8.0", path = "../eight-point" }
 lambda-twist = { optional = true, version = "0.7.0", path = "../lambda-twist" }
 akaze = { optional = true, version = "0.7.0", path = "../akaze" }
 imgshow = { optional = true, version = "0.1.0", path = "../imgshow" }
-space = { version = "0.14.0", optional = true }
+space = { version = "0.14.2", optional = true }
 hnsw = { version = "0.10.0", optional = true }
 hgg = { version = "0.3.0", optional = true }
 levenberg-marquardt = { version = "0.10.0", optional = true }

--- a/cv/src/lib.rs
+++ b/cv/src/lib.rs
@@ -81,9 +81,11 @@ pub mod knn {
         pub use hnsw::*;
     }
 
-    /// An exact nearest neighbor search algorithm that checks every item (recommended for exact search)
     #[cfg(all(feature = "space", feature = "alloc"))]
-    pub use space::LinearKnn;
+    pub use space::{KnnMap, KnnPoints, LinearKnn};
+
+    #[cfg(all(feature = "space"))]
+    pub use space::{Knn, MetricPoint, Neighbor};
 }
 
 /// Optimization algorithms

--- a/vslam-sandbox/src/main.rs
+++ b/vslam-sandbox/src/main.rs
@@ -112,13 +112,13 @@ fn main() {
     );
 
     // Add the feed.
-    let init_reconstruction = vslam.data.reconstructions().next();
-    let feed = vslam.add_feed(intrinsics, init_reconstruction);
+    let feed = vslam.add_feed(intrinsics);
 
     // Add the frames.
     for path in &opt.images {
         let image = image::open(path).expect("failed to load image");
-        if let Some(reconstruction) = vslam.add_frame(feed, &image) {
+        let frame = vslam.add_frame(feed, &image);
+        if let Some((reconstruction, _)) = vslam.data.frame(frame).view {
             if vslam.data.reconstruction(reconstruction).views.len() >= 3 {
                 vslam.optimize_reconstruction(reconstruction);
             }


### PR DESCRIPTION
This changes the internals of `cv-reconstruction`. Now, frames are matched to each other using an LSH of the bag of features representing the frame using the `hamming-lsh` crate. This has several benefits, such as being able to better tie together the reconstruction, and guards against problems that occurred with the old model where so many features were added to the ANN search that none of them were sufficiently discriminate, and the number of matches went down as the number of frames added increased. This new technique makes it so that the number of matches (shared observances of a landmark) added is retained during the whole reconstruction.

One last thing needs to be dealt with, which is merging two reconstructions. This should be possible, but requires more code. Once this is complete, this PR can be merged.