### PR TITLE
Fix the image path in the tutorial code

### DIFF
--- a/tutorial-code/chapter2-first-program/src/main.rs
+++ b/tutorial-code/chapter2-first-program/src/main.rs
@@ -3,15 +3,17 @@ use imageproc::drawing;
 use rand::Rng;
 
 fn main() {
-    let src_image = image::open("../../res/0000000000.png").expect("failed to open image file");
+    let src_image = image::open("res/0000000000.png").expect("failed to open image file");
     let mut rng = rand::thread_rng();
-    let mut canvas = drawing::Blend(src_image.to_rgba8());
+    let mut image_canvas = drawing::Blend(src_image.to_rgba8());
+
     for _ in 0..50 {
         let x = rng.gen_range(0..src_image.width()) as i32;
         let y = rng.gen_range(0..src_image.height()) as i32;
-        drawing::draw_cross_mut(&mut canvas, Rgba([0, 255, 255, 128]), x, y);
+        drawing::draw_cross_mut(&mut image_canvas, Rgba([0, 255, 255, 128]), x, y);
     }
 
-    let out_img = DynamicImage::ImageRgba8(canvas.0);
-    cv::vis::imgshow(&out_img).expect("showing image failed");
+    let out_image = DynamicImage::ImageRgba8(image_canvas.0);
+
+    cv::vis::imgshow(&out_image).expect("showing image failed");
 }

--- a/tutorial-code/chapter3-akaze-feature-extraction/src/main.rs
+++ b/tutorial-code/chapter3-akaze-feature-extraction/src/main.rs
@@ -4,15 +4,21 @@ use imageproc::drawing;
 
 fn main() {
     let src_image = image::open("res/0000000000.png").expect("failed to open image file");
-
     let threshold = 0.001f64;
     let akaze = Akaze::new(threshold);
     let (key_points, _descriptor) = akaze.extract(&src_image);
+    let mut image_canvas = drawing::Blend(src_image.to_rgba8());
 
-    let mut image = drawing::Blend(src_image.to_rgba8());
     for KeyPoint { point: (x, y), .. } in key_points {
-        drawing::draw_cross_mut(&mut image, Rgba([0, 255, 255, 128]), x as i32, y as i32);
+        drawing::draw_cross_mut(
+            &mut image_canvas,
+            Rgba([0, 255, 255, 128]),
+            x as i32,
+            y as i32,
+        );
     }
-    let out_image = DynamicImage::ImageRgba8(image.0);
+
+    let out_image = DynamicImage::ImageRgba8(image_canvas.0);
+
     cv::vis::imgshow(&out_image).expect("showing image failed");
 }


### PR DESCRIPTION
The chapter2-first-pogram `../../res/0000000000.png` were not working for me on Windows.
However this chapter-3-akaze example works great.

This commit makes both example resolve the images in a similar fashion.

Also took the liberty to change the implementations to share variable
names and spacing.