### PR TITLE
Updated dependencies and updated code: image and imageprocs

### DIFF
--- a/akaze/Cargo.toml
+++ b/akaze/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 
 [dependencies]
 cv-core = { version = "0.15.0", path = "../cv-core" }
-image = { version = "0.23.0", default-features = false }
+image = { version = "0.24", default-features = false }
 log = { version = "0.4.14", default-features = false }
 primal = { version = "0.3.0", default-features = false }
 derive_more = { version = "0.99.17", default-features = false }
-nshare = { git = "https://github.com/rust-cv/nshare.git", rev = "f743711c9dd298ebf8dfd0886986cc58a600982e", default-features = false, features = [
+nshare = { git = "https://github.com/rust-cv/nshare.git", rev = "cd4a5c007ecf4ef62c938a6ac64fd90edf895360", default-features = false, features = [
     "ndarray",
     "image",
 ] }
@@ -35,7 +35,7 @@ rand = "0.8.4"
 rand_pcg = "0.3.1"
 criterion = "0.3.5"
 pretty_env_logger = "0.4.0"
-image = "0.23.0"
+image = "0.24"
 bitarray = { version = "0.9.0", features = ["space"] }
 
 [[bench]]

--- a/akaze/src/image.rs
+++ b/akaze/src/image.rs
@@ -1,5 +1,5 @@
 use derive_more::{Deref, DerefMut};
-use image::{imageops, DynamicImage, GenericImageView, ImageBuffer, Luma};
+use image::{imageops, DynamicImage, ImageBuffer, Luma};
 use log::*;
 use ndarray::{Array2, ArrayView2, ArrayViewMut2};
 use nshare::{MutNdarray2, RefNdarray2};

--- a/akaze/src/lib.rs
+++ b/akaze/src/lib.rs
@@ -9,7 +9,7 @@ mod nonlinear_diffusion;
 mod scale_space_extrema;
 
 use crate::image::{gaussian_blur, GrayFloatImage};
-use ::image::{DynamicImage, GenericImageView, ImageResult};
+use ::image::{DynamicImage, ImageResult};
 use bitarray::BitArray;
 use cv_core::{nalgebra::Point2, ImagePoint};
 use evolution::*;

--- a/akaze/src/scale_space_extrema.rs
+++ b/akaze/src/scale_space_extrema.rs
@@ -220,7 +220,7 @@ fn compute_main_orientation(keypoint: &mut KeyPoint, evolutions: &[EvolutionStep
     let mut angs: [f32; 109usize] = [0f32; 109usize];
     let id: [usize; 13usize] = [6, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 6];
     let ratio = (1 << evolutions[keypoint.class_id].octave) as f32;
-    let s = f32::round(0.5f32 * (keypoint.size) / ratio);
+    let s = f32::round(0.5f32 * keypoint.size / ratio);
     let xf = keypoint.point.0 / ratio;
     let yf = keypoint.point.1 / ratio;
     let level = keypoint.class_id;

--- a/cv-sfm/Cargo.toml
+++ b/cv-sfm/Cargo.toml
@@ -28,9 +28,9 @@ space = { version = "0.17.0", default-features = false }
 maplit = { version = "1.0.2", default-features = false }
 log = { version = "0.4.14", default-features = false }
 itertools = { version = "0.10.3", default-features = false }
-image = { version = "0.23.0", default-features = false }
+image = { version = "0.24", default-features = false }
 ply-rs = { version = "0.1.3", default-features = false }
-imageproc = "0.22.0"
+imageproc = "0.23"
 conv = { version = "0.3.3", default-features = false }
 bitarray = { version = "0.9.0", default-features = false, features = ["space"] }
 serde = { version = "1.0.136", features = ["derive"], optional = true }

--- a/cv/Cargo.toml
+++ b/cv/Cargo.toml
@@ -59,8 +59,8 @@ hgg = { version = "0.4.1", optional = true }
 levenberg-marquardt = { version = "0.12.0", optional = true }
 arrsac = { version = "0.10.0", optional = true }
 bitarray = { version = "0.9.0", features = ["space"], optional = true }
-image = { version = "0.23.0", default-features = false, optional = true }
-imageproc = { version = "0.22.0", default-features = false, optional = true }
+image = { version = "0.24", default-features = false, optional = true }
+imageproc = { version = "0.23", default-features = false, optional = true }
 eye = { version = "0.4.1", optional = true }
 ndarray-vision = { version = "0.3.0", default-features = false, optional = true }
 

--- a/kpdraw/Cargo.toml
+++ b/kpdraw/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [dependencies]
 akaze = { version = "0.7.0", path = "../akaze" }
 structopt = "0.3.26"
-image = { version = "0.23.0", features = ["png", "jpeg"] }
-imageproc = "0.22.0"
+image = { version = "0.24", features = ["png", "jpeg"] }
+imageproc = "0.23"

--- a/kpdraw/src/main.rs
+++ b/kpdraw/src/main.rs
@@ -1,5 +1,8 @@
 use image::ImageOutputFormat;
-use std::path::PathBuf;
+use std::{
+    io::{Cursor, Write},
+    path::PathBuf,
+};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -31,8 +34,13 @@ fn main() {
     if let Some(path) = opt.output {
         image.save(path).expect("failed to write image to stdout");
     } else {
+        let mut output = Cursor::new(Vec::new());
         image
-            .write_to(&mut stdout.lock(), ImageOutputFormat::Png)
+            .write_to(&mut output, ImageOutputFormat::Png)
+            .expect("failed to write image to stdout");
+        stdout
+            .lock()
+            .write_all(&output.into_inner())
             .expect("failed to write image to stdout");
     }
 }

--- a/tutorial-code/chapter2-first-program/src/main.rs
+++ b/tutorial-code/chapter2-first-program/src/main.rs
@@ -1,5 +1,5 @@
 use cv::image::{
-    image::{self, DynamicImage, GenericImageView, Rgba},
+    image::{self, DynamicImage, Rgba},
     imageproc::drawing,
 };
 use rand::Rng;

--- a/tutorial-code/chapter3-akaze-feature-extraction/Cargo.toml
+++ b/tutorial-code/chapter3-akaze-feature-extraction/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 cv = { version = "0.6.0", path = "../../cv" }
-image = "0.23.0"
-imageproc = "0.22.0"
+image = "0.24"
+imageproc = "0.23"
 open = "2.0.2"
 tempfile = "3.3.0"

--- a/tutorial-code/chapter4-feature-matching/Cargo.toml
+++ b/tutorial-code/chapter4-feature-matching/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 cv = { version = "0.6.0", path = "../../cv" }
-image = "0.23.0"
-imageproc = "0.22.0"
+image = "0.24"
+imageproc = "0.23"
 open = "2.0.2"
 tempfile = "3.3.0"
 itertools = "0.10.3"

--- a/tutorial-code/chapter5-geometric-verification/Cargo.toml
+++ b/tutorial-code/chapter5-geometric-verification/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 cv = { version = "0.6.0", path = "../../cv" }
-image = "0.23.0"
-imageproc = "0.22.0"
+image = "0.24"
+imageproc = "0.23"
 open = "2.0.2"
 tempfile = "3.3.0"
 itertools = "0.10.3"

--- a/vslam-sandbox/Cargo.toml
+++ b/vslam-sandbox/Cargo.toml
@@ -19,7 +19,7 @@ eight-point = { version = "0.8.0", path = "../eight-point" }
 arrsac = "0.10.0"
 structopt = "0.3.26"
 serde = { version = "1.0.136", features = ["derive"] }
-image = "0.23.0"
+image = "0.24"
 rand = "0.8.4"
 rand_xoshiro = "0.6.0"
 log = "0.4.14"


### PR DESCRIPTION
This updates image to 0.24 and imageprocs to 0.23, to keep up with the other packages in the community.