### PR TITLE
Progress towards fixing akaze orientation

### DIFF
--- a/akaze/Cargo.toml
+++ b/akaze/Cargo.toml
@@ -26,6 +26,7 @@ float-ord = { version = "0.3.2", default-features = false }
 space = "0.17.0"
 bitarray = "0.9.0"
 thiserror = { version = "1.0.40", default-features = false }
+imageproc = "0.23.0"
 
 
 [dev-dependencies]

--- a/akaze/src/contrast_factor.rs
+++ b/akaze/src/contrast_factor.rs
@@ -22,8 +22,8 @@ pub fn compute_contrast_factor(
     let mut num_points: f64 = 0.0;
     let mut histogram = vec![0; num_bins];
     let gaussian = gaussian_blur(image, gradient_histogram_scale as f32);
-    let Lx = crate::derivatives::scharr_horizontal(&gaussian, 1);
-    let Ly = crate::derivatives::scharr_vertical(&gaussian, 1);
+    let Lx = crate::derivatives::simple_scharr_horizontal(&gaussian);
+    let Ly = crate::derivatives::simple_scharr_vertical(&gaussian);
     let hmax = (1..gaussian.height() - 1)
         .flat_map(|y| (1..gaussian.width() - 1).map(move |x| (x, y)))
         .map(|(x, y)| Lx.get(x, y).powi(2) as f64 + Ly.get(x, y).powi(2) as f64)

--- a/akaze/src/derivatives.rs
+++ b/akaze/src/derivatives.rs
@@ -1,6 +1,24 @@
 use crate::image::{fill_border, GrayFloatImage};
 use ndarray::{s, Array2, ArrayView2, ArrayViewMut2};
 
+pub fn simple_scharr_horizontal(image: &GrayFloatImage) -> GrayFloatImage {
+    // similar to cv::Scharr with xorder=1, yorder=0, scale=1, delta=0
+    GrayFloatImage(imageproc::filter::separable_filter(
+        &image.0,
+        &[-1., 0., 1.],
+        &[3., 10., 3.],
+    ))
+}
+
+pub fn simple_scharr_vertical(image: &GrayFloatImage) -> GrayFloatImage {
+    // similar to cv::Scharr with xorder=0, yorder=1, scale=1, delta=0
+    GrayFloatImage(imageproc::filter::separable_filter(
+        &image.0,
+        &[3., 10., 3.],
+        &[-1., 0., 1.],
+    ))
+}
+
 /// Compute the Scharr derivative horizontally
 ///
 /// The implementation of this function is using a separable kernel, for speed.

--- a/akaze/src/image.rs
+++ b/akaze/src/image.rs
@@ -1,5 +1,6 @@
 use derive_more::{Deref, DerefMut};
 use image::{DynamicImage, ImageBuffer, Luma};
+use imageproc::filter::separable_filter_equal;
 use log::*;
 use ndarray::{azip, s, Array2, ArrayView2, ArrayViewMut2};
 use nshare::{MutNdarray2, RefNdarray2};
@@ -290,11 +291,11 @@ fn gaussian_kernel(r: f32, kernel_size: usize) -> Vec<f32> {
 /// # Return value
 /// The resulting image after the filter was applied.
 pub fn gaussian_blur(image: &GrayFloatImage, r: f32) -> GrayFloatImage {
-    // a separable Gaussian kernel
-    let kernel_size = (f32::ceil(r) as usize) * 2 + 1usize;
+    assert!(r > 0.0, "sigma must be > 0.0");
+    let kernel_radius = (2.0 * r).ceil() as usize;
+    let kernel_size = kernel_radius * 2 + 1;
     let kernel = gaussian_kernel(r, kernel_size);
-    let img_horizontal = horizontal_filter(image, &kernel);
-    vertical_filter(&img_horizontal, &kernel)
+    GrayFloatImage(separable_filter_equal(image, &kernel))
 }
 
 #[cfg(test)]

--- a/akaze/src/lib.rs
+++ b/akaze/src/lib.rs
@@ -168,7 +168,7 @@ impl Akaze {
             self.base_scale_offset
         );
         let mut contrast_factor = contrast_factor::compute_contrast_factor(
-            &evolutions[0].Lsmooth,
+            image,
             self.contrast_percentile,
             1.0f64,
             self.contrast_factor_num_bins,

--- a/akaze/src/lib.rs
+++ b/akaze/src/lib.rs
@@ -195,9 +195,9 @@ impl Akaze {
             }
             evolutions[i].Lsmooth = gaussian_blur(&evolutions[i].Lt, 1.0f32);
             trace!("Gaussian blur finished.");
-            evolutions[i].Lx = derivatives::scharr_horizontal(&evolutions[i].Lsmooth, 1);
+            evolutions[i].Lx = derivatives::simple_scharr_horizontal(&evolutions[i].Lsmooth);
             trace!("Computing derivative Lx done.");
-            evolutions[i].Ly = derivatives::scharr_vertical(&evolutions[i].Lsmooth, 1);
+            evolutions[i].Ly = derivatives::simple_scharr_vertical(&evolutions[i].Lsmooth);
             trace!("Computing derivative Ly done.");
             evolutions[i].Lflow = pm_g2(&evolutions[i].Lx, &evolutions[i].Ly, contrast_factor);
             trace!("Lflow finished.");

--- a/akaze/src/nonlinear_diffusion.rs
+++ b/akaze/src/nonlinear_diffusion.rs
@@ -25,7 +25,7 @@ pub fn calculate_step(evolution_step: &mut EvolutionStep, step_size: f32) {
         &ca in conductivities.slice(s![.., ..-1]),
         &cb in conductivities.slice(s![.., 1..]),
     ) {
-        *flow = step_size * ca * cb * (b - a);
+        *flow = 0.5 * step_size * (ca + cb) * (b - a);
     });
     // Vertical flow.
     let mut vertical_flow = Array2::<f32>::zeros((dim.0 - 1, dim.1));
@@ -36,7 +36,7 @@ pub fn calculate_step(evolution_step: &mut EvolutionStep, step_size: f32) {
         &ca in conductivities.slice(s![..-1, ..]),
         &cb in conductivities.slice(s![1.., ..]),
     ) {
-        *flow = step_size * ca * cb * (b - a);
+        *flow = 0.5 * step_size * (ca + cb) * (b - a);
     });
 
     // Left


### PR DESCRIPTION
This contains my further changes for correcting Akaze's orientation, without the dump functions (the version with the dump is [here](https://github.com/enlightware/cv/tree/fix_akaze_orientation_dbg)).

I kept the corrections in different commits.

I used imageproc for running the Gaussian filters, but I retained the kernel from Akaze because it is properly normalized. I did not remove the now-unused functions `horizontal_filter` and `vertical_filter`. Should I remove them?

@vadixidav it is unclear for me whether you expected me to push directly in the branch on this repository, so I did this PR.